### PR TITLE
Map models to models instead of model

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const CarQuery = require('./lib/car-query');
 module.exports = {
   getMakes: CarQuery.request.bind(null, 'getMakes', 'make'),
   getModel: CarQuery.request.bind(null, 'getModel', 'model'),
-  getModels: CarQuery.request.bind(null, 'getModels', 'model'),
+  getModels: CarQuery.request.bind(null, 'getModels', 'models'),
   getTrims: CarQuery.request.bind(null, 'getTrims', 'trim'),
   getYears: CarQuery.request.bind(null, 'getYears', 'year'),
 };


### PR DESCRIPTION
This fixes the problem in issue #3 where the results of getModels parses incorrectly.